### PR TITLE
Primitive arrays

### DIFF
--- a/kafka-connect-xml/src/test/resources/com/github/jcustenborder/kafka/connect/xml/books.xml
+++ b/kafka-connect-xml/src/test/resources/com/github/jcustenborder/kafka/connect/xml/books.xml
@@ -18,5 +18,8 @@
         <price>24.95</price>
         <pub_date>2000-10-01</pub_date>
         <review>Least poetic poems.</review>
+        <review>...meh</review>
+        <note>2</note>
+        <price>23.12</price>
     </book>
 </x:books>

--- a/kafka-connect-xml/src/test/resources/com/github/jcustenborder/kafka/connect/xml/books.xsd
+++ b/kafka-connect-xml/src/test/resources/com/github/jcustenborder/kafka/connect/xml/books.xsd
@@ -21,8 +21,17 @@
             <xsd:element name="genre" type="xsd:string"/>
             <xsd:element name="price" type="xsd:float"/>
             <xsd:element name="pub_date" type="xsd:date"/>
-            <xsd:element name="review" type="xsd:string"/>
+            <xsd:element name="review" type="xsd:string" minOccurs="0" maxOccurs="unbounded"/>
+            <xsd:element name="note" type="xsd:int" minOccurs="0" maxOccurs="unbounded"/>
+            <xsd:element name="price" type="bks:price" minOccurs="0" maxOccurs="unbounded"/>
         </xsd:sequence>
         <xsd:attribute name="id" type="xsd:string"/>
     </xsd:complexType>
+    
+    <xs:simpleType name="price">
+      <xs:restriction base="xs:decimal">
+        <xs:fractionDigits value="2"/>
+      </xs:restriction>
+    </xs:simpleType>
+
 </xsd:schema>

--- a/xjc-kafka-connect-plugin/src/main/java/com/github/jcustenborder/kafka/connect/xml/KafkaConnectPlugin.java
+++ b/xjc-kafka-connect-plugin/src/main/java/com/github/jcustenborder/kafka/connect/xml/KafkaConnectPlugin.java
@@ -147,9 +147,9 @@ public class KafkaConnectPlugin extends AbstractParameterizablePlugin {
     add(result, this.types.schemaBuilder().staticInvoke("float64"), this.types.schema().staticRef("FLOAT64_SCHEMA"), "toFloat64", "fromFloat64", codeModel, double.class, Double.class);
     add(result, this.types.schemaBuilder().staticInvoke("int8"), this.types.schema().staticRef("INT8_SCHEMA"), "toInt8", "fromInt8", codeModel, byte.class, Byte.class);
     add(result, this.types.schemaBuilder().staticInvoke("int16"), this.types.schema().staticRef("INT16_SCHEMA"), "toInt16", "fromInt16", codeModel, short.class, Short.class);
-    add(result, this.types.schemaBuilder().staticInvoke("int32"), this.types.schema().staticRef("IN32_SCHEMA"), "toInt32", "fromInt32", codeModel, int.class, Integer.class);
-    add(result, this.types.schemaBuilder().staticInvoke("int64"), this.types.schema().staticRef("IN64_SCHEMA"), "toInt64", "fromInt64", codeModel, long.class, Long.class);
-    add(result, this.types.schemaBuilder().staticInvoke("int64"), this.types.schema().staticRef("IN64_SCHEMA"), "toInt64", "fromInt64BigInteger", codeModel, BigInteger.class);
+    add(result, this.types.schemaBuilder().staticInvoke("int32"), this.types.schema().staticRef("INT32_SCHEMA"), "toInt32", "fromInt32", codeModel, int.class, Integer.class);
+    add(result, this.types.schemaBuilder().staticInvoke("int64"), this.types.schema().staticRef("INT64_SCHEMA"), "toInt64", "fromInt64", codeModel, long.class, Long.class);
+    add(result, this.types.schemaBuilder().staticInvoke("int64"), this.types.schema().staticRef("INT64_SCHEMA"), "toInt64", "fromInt64BigInteger", codeModel, BigInteger.class);
     add(result, this.types.schemaBuilder().staticInvoke("bytes"), this.types.schema().staticRef("BYTES_SCHEMA"), "toBytes", "fromBytes", codeModel, byte[].class);
     add(result, this.types.schemaBuilder().staticInvoke("string"), this.types.schema().staticRef("STRING_SCHEMA"), "toString", "fromString", codeModel, String.class);
     add(result, this.types.decimal().staticInvoke("builder").arg(JExpr.lit(12)), null, "toDecimal", "fromDecimal", codeModel, BigDecimal.class);

--- a/xjc-kafka-connect-plugin/src/main/java/com/github/jcustenborder/kafka/connect/xml/KafkaConnectPlugin.java
+++ b/xjc-kafka-connect-plugin/src/main/java/com/github/jcustenborder/kafka/connect/xml/KafkaConnectPlugin.java
@@ -322,8 +322,12 @@ public class KafkaConnectPlugin extends AbstractParameterizablePlugin {
           JClass valueType = args.get(0);
           State valueState = type(codeModel, classOutline, field, valueType);
 
+          JExpression valueSchema = valueState.schema();
+          if (valueSchema==null) {
+        	  valueSchema = valueState.schemaBuilder().invoke("build");
+          }
           JInvocation schemaBuilder = this.types.schemaBuilder().staticInvoke("array")
-              .arg(valueState.schema());
+              .arg(valueSchema);
           builder.schemaBuilder(schemaBuilder);
           builder.readMethod("toArray");
           builder.writeMethod("fromArray");
@@ -332,11 +336,19 @@ public class KafkaConnectPlugin extends AbstractParameterizablePlugin {
         } else if (this.types.map().equals(basis)) {
           JClass keyType = args.get(0);
           State keyState = type(codeModel, classOutline, field, keyType);
+          JExpression keySchema = keyState.schema();
+          if (keySchema==null) {
+        	  keySchema = keyState.schemaBuilder().invoke("build");
+          }
           JClass valueType = args.get(1);
           State valueState = type(codeModel, classOutline, field, valueType);
+          JExpression valueSchema = valueState.schema();
+          if (valueSchema==null) {
+        	  valueSchema = valueState.schemaBuilder().invoke("build");
+          }
           JInvocation schemaBuilder = this.types.schemaBuilder().staticInvoke("map")
-              .arg(keyState.schema())
-              .arg(valueState.schema());
+              .arg(keySchema)
+              .arg(valueSchema);
           builder.schemaBuilder(schemaBuilder);
           builder.readMethod("toMap");
           builder.writeMethod("fromMap");

--- a/xjc-kafka-connect-plugin/src/test/resources/com/github/jcustenborder/kafka/connect/xml/arrays.xml
+++ b/xjc-kafka-connect-plugin/src/test/resources/com/github/jcustenborder/kafka/connect/xml/arrays.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<x:test xmlns:x="urn:test">
+  <x:test_string_array>
+    <x:element>entry 1</x:element>
+    <x:element>entry 2</x:element>
+  </x:test_string_array>
+  <x:test_int_array>
+    <x:element>1</x:element>
+    <x:element>2345</x:element>
+  </x:test_int_array>
+  <x:test_integer_array>
+    <x:element>1</x:element>
+    <x:element>-32</x:element>
+  </x:test_integer_array>
+  <x:test_decimal_array>
+    <x:element>100.232</x:element>
+    <x:element>-4667</x:element>
+  </x:test_decimal_array>
+  <x:test_double_array>
+    <x:element>100.232</x:element>
+    <x:element>-4667</x:element>
+  </x:test_double_array>
+</x:test>

--- a/xjc-kafka-connect-plugin/src/test/resources/com/github/jcustenborder/kafka/connect/xml/arrays.xsd
+++ b/xjc-kafka-connect-plugin/src/test/resources/com/github/jcustenborder/kafka/connect/xml/arrays.xsd
@@ -1,0 +1,52 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="urn:test"
+            xmlns:tst="urn:test"
+            elementFormDefault="qualified">
+
+    <xsd:element name="test">
+        <xsd:complexType>
+            <xsd:sequence>
+                <xsd:element name="test_string_array" type="tst:TestStringArray" minOccurs="0"/>
+                <xsd:element name="test_int_array" type="tst:TestIntArray" minOccurs="0"/>
+                <xsd:element name="test_integer_array" type="tst:TestIntegerArray" minOccurs="0"/>
+                <xsd:element name="test_decimal_array" type="tst:TestDecimalArray" minOccurs="0"/>
+                <xsd:element name="test_double_array" type="tst:TestDoubleArray" minOccurs="0"/>
+            </xsd:sequence>
+        </xsd:complexType>
+    </xsd:element>
+
+    <xsd:complexType name="TestStringArray">
+        <xsd:sequence>
+            <xsd:element name="element" type="xsd:string" minOccurs="0" maxOccurs="unbounded"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <!-- xsd:integer is unbounded integer number -->
+    <xsd:complexType name="TestIntegerArray">
+        <xsd:sequence>
+            <xsd:element name="element" type="xsd:integer" minOccurs="0" maxOccurs="unbounded"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <!-- xsd:int is 32-bit integer -->
+    <xsd:complexType name="TestIntArray">
+        <xsd:sequence>
+            <xsd:element name="element" type="xsd:int" minOccurs="0" maxOccurs="unbounded"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <!-- xsd:decimal is decimal number with optional decimal fraction part -->
+    <xsd:complexType name="TestDecimalArray">
+        <xsd:sequence>
+            <xsd:element name="element" type="xsd:decimal" minOccurs="0" maxOccurs="unbounded"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <!-- xsd:double is decimal number representable as 64-bit IEEE 754 floating number -->
+    <xsd:complexType name="TestDoubleArray">
+        <xsd:sequence>
+            <xsd:element name="element" type="xsd:double" minOccurs="0" maxOccurs="unbounded"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+</xsd:schema>


### PR DESCRIPTION
When some element is defined with simple type and maxOccurs greater than 1, the JAXB generates array/list. The conversion attempted to apply CONNECT_SCHEMA property to the effective type. As effect the generated code could have something like String.CONNECT_SCHEMA.

The proposed patch supports conversion of arrays of primitive types to the correct target types.