### PR TITLE
Feature/make bigdecimal scale dynamic

### DIFF
--- a/kafka-connect-xml/pom.xml
+++ b/kafka-connect-xml/pom.xml
@@ -99,6 +99,12 @@
             <version>0.11.1</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/kafka-connect-xml/src/main/java/com/github/jcustenborder/kafka/connect/xml/ConnectableHelper.java
+++ b/kafka-connect-xml/src/main/java/com/github/jcustenborder/kafka/connect/xml/ConnectableHelper.java
@@ -236,10 +236,17 @@ public class ConnectableHelper {
     struct.put(field, result);
   }
 
-  public static void toDecimal(Struct struct, String field, BigDecimal value, int scale, RoundingMode roundingMode) {
-    log.trace("toString() - field = '{}' value = '{}'", field, value);
 
-    struct.put(field, value.setScale(scale, roundingMode));
+  public static void toDecimal(Struct struct, String field, BigDecimal value, boolean forceDecimalScale, int scale,
+      RoundingMode roundingMode) {
+    log.trace("toString() - field = '{}' value = '{}' forcingScale = '{}' scale = '{}' roundingMode = '{}'", field, value,
+        forceDecimalScale, scale, roundingMode);
+
+    if (value == null || !forceDecimalScale) {
+      struct.put(field, value);
+    } else {
+      struct.put(field, value.setScale(scale, roundingMode == null ? RoundingMode.HALF_UP : roundingMode));
+    }
   }
 
   public static void toXmlgDay(Struct struct, String field, XMLGregorianCalendar value) {

--- a/kafka-connect-xml/src/main/java/com/github/jcustenborder/kafka/connect/xml/ConnectableHelper.java
+++ b/kafka-connect-xml/src/main/java/com/github/jcustenborder/kafka/connect/xml/ConnectableHelper.java
@@ -30,6 +30,7 @@ import javax.xml.datatype.XMLGregorianCalendar;
 import javax.xml.namespace.QName;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
@@ -235,9 +236,10 @@ public class ConnectableHelper {
     struct.put(field, result);
   }
 
-  public static void toDecimal(Struct struct, String field, BigDecimal value) {
+  public static void toDecimal(Struct struct, String field, BigDecimal value, int scale, RoundingMode roundingMode) {
     log.trace("toString() - field = '{}' value = '{}'", field, value);
-    struct.put(field, value);
+
+    struct.put(field, value.setScale(scale, roundingMode));
   }
 
   public static void toXmlgDay(Struct struct, String field, XMLGregorianCalendar value) {

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
     <properties>
         <jaxb.version>2.3.1</jaxb.version>
         <slf4j.version>1.7.21</slf4j.version>
-        <junit.version>5.0.0</junit.version>
+        <junit.version>5.4.2</junit.version>
         <guava.version>18.0</guava.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <logback.version>1.1.8</logback.version>

--- a/xjc-kafka-connect-plugin/src/main/java/com/github/jcustenborder/kafka/connect/xml/KafkaConnectPlugin.java
+++ b/xjc-kafka-connect-plugin/src/main/java/com/github/jcustenborder/kafka/connect/xml/KafkaConnectPlugin.java
@@ -176,9 +176,12 @@ public class KafkaConnectPlugin extends AbstractParameterizablePlugin {
     add(result, this.types.schemaBuilder().staticInvoke("bytes"), this.types.schema().staticRef("BYTES_SCHEMA"), "toBytes", "fromBytes", codeModel, byte[].class);
     add(result, this.types.schemaBuilder().staticInvoke("string"), this.types.schema().staticRef("STRING_SCHEMA"), "toString", "fromString", codeModel, String.class);
     add(result, this.types.decimal().staticInvoke("builder").arg(JExpr.lit(config.getDecimalScale())), null,
-            new MethodDescriptor("toDecimal",  ImmutableList.of(JExpr.lit(config.getDecimalScale()), codeModel.ref(RoundingMode.class).staticInvoke("valueOf").arg(JExpr.lit(config.getRoundingMode().name())))),
-            new MethodDescriptor("fromDecimal", emptyList()),
-            codeModel, BigDecimal.class);
+        new MethodDescriptor("toDecimal", ImmutableList.of(
+            JExpr.lit(config.isForceDecimalScale()),
+            JExpr.lit(config.getDecimalScale()),
+            codeModel.ref(RoundingMode.class).staticInvoke("valueOf").arg(JExpr.lit(config.getRoundingMode().name())))),
+        new MethodDescriptor("fromDecimal", emptyList()),
+        codeModel, BigDecimal.class);
 
     add(result, this.types.connectableHelper().staticInvoke("qnameBuilder"), null, "toQname", "fromQname", codeModel, QName.class);
     add(result, this.types.schemaBuilder().staticInvoke("int64"), this.types.schema().staticRef("IN64_SCHEMA"), "toDuration", "fromDuration", codeModel, Duration.class);

--- a/xjc-kafka-connect-plugin/src/main/java/com/github/jcustenborder/kafka/connect/xml/KafkaConnectPlugin.java
+++ b/xjc-kafka-connect-plugin/src/main/java/com/github/jcustenborder/kafka/connect/xml/KafkaConnectPlugin.java
@@ -16,6 +16,7 @@
 package com.github.jcustenborder.kafka.connect.xml;
 
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.sun.codemodel.ClassType;
 import com.sun.codemodel.JBlock;
@@ -33,6 +34,7 @@ import com.sun.codemodel.JVar;
 import com.sun.tools.xjc.Options;
 import com.sun.tools.xjc.outline.ClassOutline;
 import com.sun.tools.xjc.outline.Outline;
+import org.apache.commons.lang3.Validate;
 import org.jvnet.jaxb2_commons.plugin.AbstractParameterizablePlugin;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,12 +46,15 @@ import javax.xml.datatype.Duration;
 import javax.xml.namespace.QName;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import static com.sun.codemodel.JType.parse;
+import static java.util.Collections.emptyList;
+
 
 public class KafkaConnectPlugin extends AbstractParameterizablePlugin {
   static final String TO_CONNECT_STRUCT = "toStruct";
@@ -58,6 +63,7 @@ public class KafkaConnectPlugin extends AbstractParameterizablePlugin {
   static final Class<?> CLASS_JREFERENCEDCLASS;
   private static final Logger log = LoggerFactory.getLogger(KafkaConnectPlugin.class);
   private static final String CONNECT_SCHEMA_FIELD = "CONNECT_SCHEMA";
+  private final KafkaConnectPluginConfig config;
 
   static {
     try {
@@ -68,10 +74,18 @@ public class KafkaConnectPlugin extends AbstractParameterizablePlugin {
     }
   }
 
-  Types types;
-  Map<JType, StaticTypeState> jTypeLookup;
-  Map<String, XmlTypeState> xmlTypeLookup;
-  Map<JType, DefinedTypeState> definedTypeStateLookup = new HashMap<>();
+  private Types types;
+  private Map<JType, StaticTypeState> jTypeLookup;
+  private Map<String, XmlTypeState> xmlTypeLookup;
+  private Map<JType, DefinedTypeState> definedTypeStateLookup = new HashMap<>();
+
+  public KafkaConnectPlugin() {
+    this(null);
+  }
+
+  public KafkaConnectPlugin(KafkaConnectPluginConfig config) {
+    this.config = config == null ? new KafkaConnectPluginConfig.Builder().build(): config;
+  }
 
   @Override
   public String getOptionName() {
@@ -117,7 +131,14 @@ public class KafkaConnectPlugin extends AbstractParameterizablePlugin {
     return schemaVariable;
   }
 
-  void add(Map<JType, StaticTypeState> result, JExpression schemaBuilder, JExpression schema, String readMethod, String writeMethod, JCodeModel codeModel, Class<?>... classes) {
+
+  void add(Map<JType, StaticTypeState> result, JExpression schemaBuilder, JExpression schema, String readMethod, String writeMethod,
+          JCodeModel codeModel, Class<?>... classes) {
+    add(result, schemaBuilder, schema, new MethodDescriptor(readMethod, emptyList()), new MethodDescriptor(writeMethod, emptyList()), codeModel, classes);
+  }
+
+
+  void add(Map<JType, StaticTypeState> result, JExpression schemaBuilder, JExpression schema, MethodDescriptor readMethod, MethodDescriptor writeMethod, JCodeModel codeModel, Class<?>... classes) {
     ImmutableStaticTypeState.Builder builder = ImmutableStaticTypeState.builder();
 
     for (Class<?> cls : classes) {
@@ -129,8 +150,10 @@ public class KafkaConnectPlugin extends AbstractParameterizablePlugin {
       }
       builder.addTypes(type);
     }
-    builder.readMethod(readMethod);
-    builder.writeMethod(writeMethod);
+    builder.readMethod(readMethod.getMethodName());
+    builder.readMethodArgs(readMethod.getMethodArgs());
+    builder.writeMethod(writeMethod.getMethodName());
+    builder.writeMethodArgs(writeMethod.getMethodArgs());
     builder.schema(schema);
     builder.schemaBuilder(schemaBuilder);
     StaticTypeState typeState = builder.build();
@@ -152,7 +175,10 @@ public class KafkaConnectPlugin extends AbstractParameterizablePlugin {
     add(result, this.types.schemaBuilder().staticInvoke("int64"), this.types.schema().staticRef("INT64_SCHEMA"), "toInt64", "fromInt64BigInteger", codeModel, BigInteger.class);
     add(result, this.types.schemaBuilder().staticInvoke("bytes"), this.types.schema().staticRef("BYTES_SCHEMA"), "toBytes", "fromBytes", codeModel, byte[].class);
     add(result, this.types.schemaBuilder().staticInvoke("string"), this.types.schema().staticRef("STRING_SCHEMA"), "toString", "fromString", codeModel, String.class);
-    add(result, this.types.decimal().staticInvoke("builder").arg(JExpr.lit(12)), null, "toDecimal", "fromDecimal", codeModel, BigDecimal.class);
+    add(result, this.types.decimal().staticInvoke("builder").arg(JExpr.lit(config.getDecimalScale())), null,
+            new MethodDescriptor("toDecimal",  ImmutableList.of(JExpr.lit(config.getDecimalScale()), codeModel.ref(RoundingMode.class).staticInvoke("valueOf").arg(JExpr.lit(config.getRoundingMode().name())))),
+            new MethodDescriptor("fromDecimal", emptyList()),
+            codeModel, BigDecimal.class);
 
     add(result, this.types.connectableHelper().staticInvoke("qnameBuilder"), null, "toQname", "fromQname", codeModel, QName.class);
     add(result, this.types.schemaBuilder().staticInvoke("int64"), this.types.schema().staticRef("IN64_SCHEMA"), "toDuration", "fromDuration", codeModel, Duration.class);
@@ -466,7 +492,7 @@ public class KafkaConnectPlugin extends AbstractParameterizablePlugin {
 
   @Override
   public boolean run(Outline model, Options options, ErrorHandler errorHandler) throws
-      SAXException {
+          SAXException {
     try {
       JCodeModel codeModel = model.getCodeModel();
       setupImportedClasses(codeModel);
@@ -489,4 +515,26 @@ public class KafkaConnectPlugin extends AbstractParameterizablePlugin {
   }
 
 
+  private static class MethodDescriptor {
+    private final String methodName;
+    private final List<JExpression> methodArgs;
+
+
+    private MethodDescriptor(final String methodName, final List<JExpression> methodArgs) {
+      Validate.notNull(methodName, "methodName must not be null.");
+
+      this.methodName = methodName;
+      this.methodArgs = methodArgs == null ? emptyList(): methodArgs;
+    }
+
+
+    public String getMethodName() {
+      return methodName;
+    }
+
+
+    public List<JExpression> getMethodArgs() {
+      return methodArgs;
+    }
+  }
 }

--- a/xjc-kafka-connect-plugin/src/main/java/com/github/jcustenborder/kafka/connect/xml/KafkaConnectPluginConfig.java
+++ b/xjc-kafka-connect-plugin/src/main/java/com/github/jcustenborder/kafka/connect/xml/KafkaConnectPluginConfig.java
@@ -1,0 +1,103 @@
+/**
+ * Copyright © 2017 Jeremy Custenborder (jcustenborder@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.jcustenborder.kafka.connect.xml;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Objects;
+
+import java.math.RoundingMode;
+
+
+public class KafkaConnectPluginConfig {
+    private final int decimalScale;
+    private final RoundingMode roundingMode;
+
+
+    protected KafkaConnectPluginConfig(final int decimalScale, final RoundingMode roundingMode) {
+        this.decimalScale = decimalScale;
+        this.roundingMode = roundingMode;
+    }
+
+
+    /**
+     * The scale to force all  xs:decimal numbers into.
+     */
+    public int getDecimalScale() {
+        return decimalScale;
+    }
+
+
+    /**
+     * The RoudingMode to use in forcing xs:decimal numbers into the defined decimal scale. Default is ROUND_HALF_UP.
+     **/
+    public RoundingMode getRoundingMode() {
+        return roundingMode;
+    }
+
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final KafkaConnectPluginConfig that = (KafkaConnectPluginConfig) o;
+        return decimalScale == that.decimalScale &&
+                roundingMode == that.roundingMode;
+    }
+
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(decimalScale, roundingMode);
+    }
+
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                .add("decimalScale", decimalScale)
+                .add("roundingMode", roundingMode)
+                .toString();
+    }
+
+
+    public static class Builder {
+        private int scale = 12;
+        private RoundingMode roundingMode = RoundingMode.HALF_UP;
+
+
+        public Builder withDecimalScale(int scale) {
+            this.scale = scale;
+
+            return this;
+        }
+
+
+        public Builder withRoundingMode(RoundingMode roundingMode) {
+            this.roundingMode = roundingMode;
+
+            return this;
+        }
+
+
+        public KafkaConnectPluginConfig build() {
+            return new KafkaConnectPluginConfig(scale, roundingMode);
+        }
+    }
+}

--- a/xjc-kafka-connect-plugin/src/main/java/com/github/jcustenborder/kafka/connect/xml/KafkaConnectPluginConfig.java
+++ b/xjc-kafka-connect-plugin/src/main/java/com/github/jcustenborder/kafka/connect/xml/KafkaConnectPluginConfig.java
@@ -22,82 +22,103 @@ import java.math.RoundingMode;
 
 
 public class KafkaConnectPluginConfig {
-    private final int decimalScale;
-    private final RoundingMode roundingMode;
+
+  private final boolean forceDecimalScale;
+  private final int decimalScale;
+  private final RoundingMode roundingMode;
 
 
-    protected KafkaConnectPluginConfig(final int decimalScale, final RoundingMode roundingMode) {
-        this.decimalScale = decimalScale;
-        this.roundingMode = roundingMode;
+  protected KafkaConnectPluginConfig(final boolean forceDecimalScale, final int decimalScale, final RoundingMode roundingMode) {
+    this.forceDecimalScale = forceDecimalScale;
+    this.decimalScale = decimalScale;
+    this.roundingMode = roundingMode;
+  }
+
+
+  /**
+   * Apply decimal scaling to force any values to the scale specified in the schema
+   */
+  public boolean isForceDecimalScale() {
+    return forceDecimalScale;
+  }
+
+
+  /**
+   * The scale to force all xs:decimal numbers into.
+   */
+  public int getDecimalScale() {
+    return decimalScale;
+  }
+
+
+  /**
+   * The RoudingMode to use in forcing xs:decimal numbers into the defined decimal scale. Default is ROUND_HALF_UP.
+   **/
+  public RoundingMode getRoundingMode() {
+    return roundingMode;
+  }
+
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("forceDecimalScale", forceDecimalScale)
+        .add("decimalScale", decimalScale)
+        .add("roundingMode", roundingMode)
+        .toString();
+  }
+
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final KafkaConnectPluginConfig that = (KafkaConnectPluginConfig) o;
+    return forceDecimalScale == that.forceDecimalScale &&
+        decimalScale == that.decimalScale &&
+        roundingMode == that.roundingMode;
+  }
+
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(forceDecimalScale, decimalScale, roundingMode);
+  }
+
+
+  public static class Builder {
+    private boolean forceDecimalScale = false;
+    private int scale = 12;
+    private RoundingMode roundingMode = RoundingMode.HALF_UP;
+
+
+    public Builder withDecimalScale(int scale) {
+      this.scale = scale;
+
+      return this;
     }
 
 
-    /**
-     * The scale to force all  xs:decimal numbers into.
-     */
-    public int getDecimalScale() {
-        return decimalScale;
+    public Builder withForceDecimalScale(boolean forceDecimalScale) {
+      this.forceDecimalScale = forceDecimalScale;
+
+      return this;
     }
 
 
-    /**
-     * The RoudingMode to use in forcing xs:decimal numbers into the defined decimal scale. Default is ROUND_HALF_UP.
-     **/
-    public RoundingMode getRoundingMode() {
-        return roundingMode;
+    public Builder withRoundingMode(RoundingMode roundingMode) {
+      this.roundingMode = roundingMode;
+
+      return this;
     }
 
 
-    @Override
-    public boolean equals(final Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        final KafkaConnectPluginConfig that = (KafkaConnectPluginConfig) o;
-        return decimalScale == that.decimalScale &&
-                roundingMode == that.roundingMode;
+    public KafkaConnectPluginConfig build() {
+      return new KafkaConnectPluginConfig(forceDecimalScale, scale, roundingMode);
     }
-
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(decimalScale, roundingMode);
-    }
-
-
-    @Override
-    public String toString() {
-        return MoreObjects.toStringHelper(this)
-                .add("decimalScale", decimalScale)
-                .add("roundingMode", roundingMode)
-                .toString();
-    }
-
-
-    public static class Builder {
-        private int scale = 12;
-        private RoundingMode roundingMode = RoundingMode.HALF_UP;
-
-
-        public Builder withDecimalScale(int scale) {
-            this.scale = scale;
-
-            return this;
-        }
-
-
-        public Builder withRoundingMode(RoundingMode roundingMode) {
-            this.roundingMode = roundingMode;
-
-            return this;
-        }
-
-
-        public KafkaConnectPluginConfig build() {
-            return new KafkaConnectPluginConfig(scale, roundingMode);
-        }
-    }
+  }
 }


### PR DESCRIPTION
See what you think @jcustenborder.

I've made the BigDecimal scale forcible - i'm finding that the fixed BigDecimal scaling is breaking downstream where we try to get the BD back out of the Struct - it complains that the scale of the BD doesn't match the schema. I've made it configurable and default 'off' so it doesn't impact current users. I will have to updated the kafka-connect-transform-xml repo to engage the configuration parameters too - next job.

Regards,
Jon